### PR TITLE
Precomputed block logging local compatible

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -352,15 +352,15 @@ let setup_daemon logger =
          with full proving (full), snark-testing with dummy proofs (check), or \
          dummy proofs (none)"
   and plugins = plugin_flag
-  and precomputed_blocks_path =
-    flag "--precomputed-blocks-path"
-      ~aliases:[ "precomputed-blocks-path" ]
+  and precomputed_blocks_file =
+    flag "--precomputed-blocks-file"
+      ~aliases:[ "precomputed-blocks-file" ]
       (optional string)
-      ~doc:
-        "PATH Path to write precomputed blocks to, for replay or archiving. If \
-         path is a directory, precomputed blocks will be logged to individual \
-         files within this directory. If path is a file, they will be appended \
-         to this file. Otherwise, precomputed blocks will not be dumped."
+      ~doc:"PATH File to append precomputed blocks to, for replay or archiving."
+  and precomputed_blocks_dir =
+    flag "--precomputed-blocks-dir"
+      ~aliases:[ "precomputed-blocks-dir" ]
+      (optional string) ~doc:"PATH Directory to dump precomputed blocks to."
   and log_precomputed_blocks =
     flag "--log-precomputed-blocks"
       ~aliases:[ "log-precomputed-blocks" ]
@@ -1308,7 +1308,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~consensus_local_state ~is_archive_rocksdb
                  ~work_reassignment_wait ~archive_process_location
                  ~log_block_creation ~precomputed_values ~start_time
-                 ?precomputed_blocks_path ~log_precomputed_blocks
+                 ?precomputed_blocks_file ?precomputed_blocks_dir ~log_precomputed_blocks
                  ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
                  ~uptime_submitter_keypair ~stop_time ~node_status_url
                  ~node_status_type () )

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -353,15 +353,21 @@ let setup_daemon logger =
          dummy proofs (none)"
   and plugins = plugin_flag
   and precomputed_blocks_path =
-    flag "--precomputed-blocks-file"
-      ~aliases:[ "precomputed-blocks-file" ]
+    flag "--precomputed-blocks-path"
+      ~aliases:[ "precomputed-blocks-path" ]
       (optional string)
-      ~doc:"PATH Path to write precomputed blocks to, for replay or archiving"
+      ~doc:
+        "PATH Path to write precomputed blocks to, for replay or archiving. If \
+         PATH is a directory, precomputed blocks will be logged to individual \
+         files within this directory. Otherwise, they will be appended to the \
+         same file."
   and log_precomputed_blocks =
     flag "--log-precomputed-blocks"
       ~aliases:[ "log-precomputed-blocks" ]
       (optional_with_default false bool)
-      ~doc:"true|false Include precomputed blocks in the log (default: false)"
+      ~doc:
+        "true|false Include precomputed blocks in the log (default: false). \
+         See also --precomputed-block-path for additional functionality."
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -358,16 +358,14 @@ let setup_daemon logger =
       (optional string)
       ~doc:
         "PATH Path to write precomputed blocks to, for replay or archiving. If \
-         PATH is a directory, precomputed blocks will be logged to individual \
-         files within this directory. Otherwise, they will be appended to the \
-         same file."
+         path is a directory, precomputed blocks will be logged to individual \
+         files within this directory. If path is a file, they will be appended \
+         to this file. Otherwise, precomputed blocks will not be dumped."
   and log_precomputed_blocks =
     flag "--log-precomputed-blocks"
       ~aliases:[ "log-precomputed-blocks" ]
       (optional_with_default false bool)
-      ~doc:
-        "true|false Include precomputed blocks in the log (default: false). \
-         See also --precomputed-block-path for additional functionality."
+      ~doc:"true|false Include precomputed blocks in the log (default: false)"
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1308,10 +1308,10 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~consensus_local_state ~is_archive_rocksdb
                  ~work_reassignment_wait ~archive_process_location
                  ~log_block_creation ~precomputed_values ~start_time
-                 ?precomputed_blocks_file ?precomputed_blocks_dir ~log_precomputed_blocks
-                 ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
-                 ~uptime_submitter_keypair ~stop_time ~node_status_url
-                 ~node_status_type () )
+                 ?precomputed_blocks_file ?precomputed_blocks_dir
+                 ~log_precomputed_blocks ~upload_blocks_to_gcloud
+                 ~block_reward_threshold ~uptime_url ~uptime_submitter_keypair
+                 ~stop_time ~node_status_url () )
           in
           { Coda_initialization.coda
           ; client_trustlist

--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -98,6 +98,21 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
               Pipe.write_without_pushback writer { With_hash.data; hash } ) )
       ~if_not_found:ignore
   in
+  let dump_precomputed_blocks =
+    Option.is_some (fst !precomputed_block_writer)
+  in
+  let network =
+    match Core.Sys.getenv "NETWORK_NAME" with
+    | Some network ->
+        if upload_blocks_to_gcloud || dump_precomputed_blocks then
+          [%log info] "NETWORK_NAME environment variable set to %s" network ;
+        network
+    | _ ->
+        if log_precomputed_blocks || dump_precomputed_blocks then
+          [%log warn]
+            "NETWORK_NAME environment variable not set. Default to 'mainnet'" ;
+        "mainnet"
+  in
   let gcloud_keyfile =
     match Core.Sys.getenv "GCLOUD_KEYFILE" with
     | Some keyfile ->
@@ -109,6 +124,20 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
           [%log warn]
             "GCLOUD_KEYFILE environment variable not set. Must be set to use \
              upload_blocks_to_gcloud" ;
+        None
+  in
+  let gcloud_bucket =
+    match Core.Sys.getenv "GCLOUD_BLOCK_UPLOAD_BUCKET" with
+    | Some bucket ->
+        if upload_blocks_to_gcloud then
+          [%log info]
+            "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable set to %s" bucket ;
+        Some bucket
+    | _ ->
+        if upload_blocks_to_gcloud then
+          [%log warn]
+            "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable not set. Must be \
+            set to use upload_blocks_to_gcloud" ;
         None
   in
   Option.iter (fst !precomputed_block_writer) ~f:(fun path ->
@@ -134,7 +163,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
             Mina_block.Validated.forget new_block
             |> State_hash.With_state_hashes.state_hash
           in
-          (let path, _log = !precomputed_block_writer in
+          (let path, log = !precomputed_block_writer in
            let precomputed_block =
              lazy
                (let scheduled_time = Block_time.now time_controller in
@@ -148,28 +177,8 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
            (* Upload precomputed blocks to gcloud *)
            ( if upload_blocks_to_gcloud then
              let json = Yojson.Safe.to_string (Lazy.force precomputed_block) in
-             let network =
-               match Core.Sys.getenv "NETWORK_NAME" with
-               | Some network ->
-                   Some network
-               | _ ->
-                   [%log warn]
-                     "NETWORK_NAME environment variable not set. Must be set \
-                      to use upload_blocks_to_gcloud" ;
-                   None
-             in
-             let bucket =
-               match Core.Sys.getenv "GCLOUD_BLOCK_UPLOAD_BUCKET" with
-               | Some bucket ->
-                   Some bucket
-               | _ ->
-                   [%log warn]
-                     "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable not set. \
-                      Must be set to use upload_blocks_to_gcloud" ;
-                   None
-             in
-             match (gcloud_keyfile, network, bucket) with
-             | Some _, Some network, Some bucket ->
+             match (gcloud_keyfile, gcloud_bucket) with
+             | Some _, Some bucket ->
                  let hash_string = State_hash.to_base58_check hash in
                  [%log info]
                    ~metadata:
@@ -238,65 +247,47 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                  () ) ;
            (* Log precomputed blocks locally *)
            Option.iter path ~f:(fun path ->
-               if log_precomputed_blocks then
-                 let json =
-                   Yojson.Safe.to_string (Lazy.force precomputed_block)
-                 in
-                 match path with
-                 | `Path path ->
-                     (* original logging functionality, appends to single file *)
-                     Out_channel.with_file ~append:true path
-                       ~f:(fun out_channel ->
-                         Out_channel.output_lines out_channel [ json ] )
-                 | `Path_dir path -> (
-                     (* log precomputed blocks to individual files in the directory *)
-                     let network =
-                       match Core.Sys.getenv "NETWORK_NAME" with
-                       | Some network ->
-                           Some network
-                       | _ ->
-                           [%log warn]
-                             "NETWORK_NAME environment variable not set. \
-                              Default to 'mainnet'" ;
-                           Some "mainnet"
-                     in
-                     match network with
-                     | Some network ->
-                         let hash_string = State_hash.to_base58_check hash in
-                         let height =
-                           Mina_block.Validated.forget new_block
-                           |> With_hash.data |> Mina_block.blockchain_length
-                           |> Mina_numbers.Length.to_string
-                         in
-                         let name =
-                           sprintf "%s-%s-%s.json" network height hash_string
-                         in
-                         let fpath =
-                           Core.Filename.(parts path @ [ name ] |> of_parts)
-                         in
-                         Out_channel.with_file ~append:false fpath
-                           ~f:(fun out_channel ->
-                             Out_channel.output_lines out_channel [ json ] ) ;
-                         [%log info]
-                           ~metadata:
-                             [ ("block", `String name)
-                             ; ("path", `String path)
-                             ; ( "time"
-                               , `String
-                                   Time.(
-                                     now ()
-                                     |> to_string_iso8601_basic ~zone:Zone.utc)
-                               )
-                             ]
-                           "Logged precomputed $block to $path at $time"
-                     | None ->
-                         () )
-               else
-                 [%log info]
-                   ~metadata:
-                     [ ("state_hash", `String (State_hash.to_base58_check hash))
-                     ]
-                   "Saw block with state hash $state_hash" ) ) ;
+               let json =
+                 Yojson.Safe.to_string (Lazy.force precomputed_block)
+               in
+               match path with
+               | `Path path ->
+                   (* original logging functionality, appends to single file *)
+                   Out_channel.with_file ~append:true path
+                     ~f:(fun out_channel ->
+                       Out_channel.output_lines out_channel [ json ] )
+               | `Path_dir path ->
+                   (* log precomputed blocks to individual files in the directory *)
+                   let hash_string = State_hash.to_base58_check hash in
+                   let height =
+                     Mina_block.Validated.forget new_block
+                     |> With_hash.data |> Mina_block.blockchain_length
+                     |> Mina_numbers.Length.to_string
+                   in
+                   let name =
+                     sprintf "%s-%s-%s.json" network height hash_string
+                   in
+                   let fpath =
+                     Core.Filename.(parts path @ [ name ] |> of_parts)
+                   in
+                   Out_channel.with_file ~append:false fpath
+                     ~f:(fun out_channel ->
+                       Out_channel.output_lines out_channel [ json ] ) ;
+                   [%log info]
+                     ~metadata:
+                       [ ("block", `String name); ("path", `String path) ]
+                     "Logged precomputed $block to $path" ) ;
+           if log_precomputed_blocks then
+             [%log info] "Saw block with state hash $state_hash"
+               ~metadata:
+                 (let state_hash_data =
+                    [ ("state_hash", `String (State_hash.to_base58_check hash))
+                    ]
+                  in
+                  if is_some log then
+                    state_hash_data
+                    @ [ ("precomputed_block", Lazy.force precomputed_block) ]
+                  else state_hash_data ) ) ;
           let new_block_no_hash =
             Mina_block.Validated.forget new_block |> With_hash.data
           in

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -51,7 +51,8 @@ type t =
   ; log_block_creation : bool [@default false]
   ; precomputed_values : Precomputed_values.t
   ; start_time : Time.t
-  ; precomputed_blocks_path : string option
+  ; precomputed_blocks_file : string option
+  ; precomputed_blocks_dir : string option
   ; log_precomputed_blocks : bool
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1990,12 +1990,20 @@ let create ?wallets (config : Config.t) =
              --precomputed-blocks-path DIR and --log-precomputed-blocks true *)
           let precomputed_block_writer =
             ref
-              ( Option.map config.precomputed_blocks_path ~f:(fun path ->
-                    match Core.Unix.(stat path).st_kind with
-                    | S_DIR ->
-                        `Path_dir path
-                    | _ ->
-                        `Path path )
+              ( ( try
+                    Option.map config.precomputed_blocks_path ~f:(fun path ->
+                        match Core.Unix.(lstat path).st_kind with
+                        | S_DIR ->
+                            `Path_dir path
+                        | S_REG ->
+                            `Path path
+                        | _ ->
+                            [%log' error config.logger]
+                              ~metadata:[ ("path", `String path) ]
+                              "$path is not a regular Unix file or directory. \
+                               Local precomputed block logging disabled." ;
+                            failwith "No precomputed block logging" )
+                  with _ -> None )
               , if config.log_precomputed_blocks then Some `Log else None )
           in
           let subscriptions =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -10,6 +10,7 @@ module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
 module Subscriptions = Coda_subscriptions
+module Precomputed_block_writer = Subscriptions.Precomputed_block_writer
 module Snark_worker_lib = Snark_worker
 module Timeout = Timeout_lib.Core_time
 
@@ -104,8 +105,7 @@ type t =
       Daemon_rpcs.Types.Status.Next_producer_timing.t option
   ; subscriptions : Coda_subscriptions.t
   ; sync_status : Sync_status.t Mina_incremental.Status.Observer.t
-  ; precomputed_block_writer :
-      ([ `Path of string | `Path_dir of string ] option * [ `Log ] option) ref
+  ; precomputed_block_writer : Precomputed_block_writer.t ref
   ; block_production_status :
       [ `Producing | `Producing_in_ms of float | `Free ] ref
   ; in_memory_reverse_structured_log_messages_for_integration_test :
@@ -1986,25 +1986,37 @@ let create ?wallets (config : Config.t) =
               Archive_client.run ~logger:config.logger
                 ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
                 archive_process_port ) ;
-          (* To log precomputed blocks to individual files, set both
-             --precomputed-blocks-path DIR and --log-precomputed-blocks true *)
+          (* Local block writing *)
           let precomputed_block_writer =
-            ref
-              ( ( try
-                    Option.map config.precomputed_blocks_path ~f:(fun path ->
-                        match Core.Unix.(lstat path).st_kind with
-                        | S_DIR ->
-                            `Path_dir path
-                        | S_REG ->
-                            `Path path
-                        | _ ->
-                            [%log' error config.logger]
-                              ~metadata:[ ("path", `String path) ]
-                              "$path is not a regular Unix file or directory. \
-                               Local precomputed block logging disabled." ;
-                            failwith "No precomputed block logging" )
-                  with _ -> None )
-              , if config.log_precomputed_blocks then Some `Log else None )
+            let file =
+              try
+                Option.map config.precomputed_blocks_file ~f:(fun path ->
+                    match Core.Unix.(lstat path).st_kind with
+                    | S_REG ->
+                        path
+                    | _ ->
+                        [%log' error config.logger]
+                          ~metadata:[ ("path", `String path) ]
+                          "$path is not a regular Unix file. \
+                           Local precomputed block appending disabled." ;
+                        failwith "No precomputed block appending" )
+              with _ -> None
+            in
+            let dir =
+              try
+                Option.map config.precomputed_blocks_dir ~f:(fun path ->
+                    match Core.Unix.(lstat path).st_kind with
+                    | S_DIR ->
+                        path
+                    | _ ->
+                        [%log' error config.logger]
+                          ~metadata:[ ("path", `String path) ]
+                          "$path is not a regular Unix directory. \
+                           Local precomputed block dumping disabled." ;
+                        failwith "No precomputed block dumping" )
+              with _ -> None
+            in
+            ref { Precomputed_block_writer.file; dir; log = config.log_precomputed_blocks }
           in
           let subscriptions =
             Coda_subscriptions.create ~logger:config.logger
@@ -2013,7 +2025,6 @@ let create ?wallets (config : Config.t) =
               ~is_storing_all:config.is_archive_rocksdb
               ~upload_blocks_to_gcloud:config.upload_blocks_to_gcloud
               ~time_controller:config.time_controller ~precomputed_block_writer
-              ~log_precomputed_blocks:config.log_precomputed_blocks
           in
           let open Mina_incremental.Status in
           let transition_frontier_incr =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -105,7 +105,7 @@ type t =
   ; subscriptions : Coda_subscriptions.t
   ; sync_status : Sync_status.t Mina_incremental.Status.Observer.t
   ; precomputed_block_writer :
-      ([ `Path of string ] option * [ `Log ] option) ref
+      ([ `Path of string | `Path_dir of string ] option * [ `Log ] option) ref
   ; block_production_status :
       [ `Producing | `Producing_in_ms of float | `Free ] ref
   ; in_memory_reverse_structured_log_messages_for_integration_test :
@@ -1986,10 +1986,16 @@ let create ?wallets (config : Config.t) =
               Archive_client.run ~logger:config.logger
                 ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
                 archive_process_port ) ;
+          (* To log precomputed blocks to individual files, set both
+             --precomputed-blocks-path DIR and --log-precomputed-blocks true *)
           let precomputed_block_writer =
             ref
               ( Option.map config.precomputed_blocks_path ~f:(fun path ->
-                    `Path path )
+                    match Core.Unix.(stat path).st_kind with
+                    | S_DIR ->
+                        `Path_dir path
+                    | _ ->
+                        `Path path )
               , if config.log_precomputed_blocks then Some `Log else None )
           in
           let subscriptions =
@@ -1999,6 +2005,7 @@ let create ?wallets (config : Config.t) =
               ~is_storing_all:config.is_archive_rocksdb
               ~upload_blocks_to_gcloud:config.upload_blocks_to_gcloud
               ~time_controller:config.time_controller ~precomputed_block_writer
+              ~log_precomputed_blocks:config.log_precomputed_blocks
           in
           let open Mina_incremental.Status in
           let transition_frontier_incr =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1997,8 +1997,8 @@ let create ?wallets (config : Config.t) =
                     | _ ->
                         [%log' error config.logger]
                           ~metadata:[ ("path", `String path) ]
-                          "$path is not a regular Unix file. \
-                           Local precomputed block appending disabled." ;
+                          "$path is not a regular Unix file. Local precomputed \
+                           block appending disabled." ;
                         failwith "No precomputed block appending" )
               with _ -> None
             in
@@ -2011,12 +2011,16 @@ let create ?wallets (config : Config.t) =
                     | _ ->
                         [%log' error config.logger]
                           ~metadata:[ ("path", `String path) ]
-                          "$path is not a regular Unix directory. \
-                           Local precomputed block dumping disabled." ;
+                          "$path is not a regular Unix directory. Local \
+                           precomputed block dumping disabled." ;
                         failwith "No precomputed block dumping" )
               with _ -> None
             in
-            ref { Precomputed_block_writer.file; dir; log = config.log_precomputed_blocks }
+            ref
+              { Precomputed_block_writer.file
+              ; dir
+              ; log = config.log_precomputed_blocks
+              }
           in
           let subscriptions =
             Coda_subscriptions.create ~logger:config.logger

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -9,6 +9,7 @@ module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
 module Subscriptions = Coda_subscriptions
+module Precomputed_block_writer = Subscriptions.Precomputed_block_writer
 
 type t
 


### PR DESCRIPTION
This PR adds a local precomputed block (PCB) writing functionality to the Mina daemon. To use it, simply set the new CLI flag `--precomputed-blocks-dir PATH` when you start the daemon. Block names are consistent with the current PCB naming convention `{network}-{height}-{state_hash}.json`.

The new functionality is only triggered when `PATH` is a Unix directory. Otherwise, a warning will be logged and no block writing happens.

CLI flags
- `--precomputed-blocks-dir` added
- `--precomputed-blocks-path` is changed to `--precomputed-blocks-file`

Minor improvements to logging wrt block writing

Fixes https://github.com/Granola-Team/mina-indexer/issues/696